### PR TITLE
Added Swagger config for Claim and Eligibility modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,25 @@
             <version>2.3.1</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.1.0</version>
+        </dependency>
+
+        <!-- Hibernate Validator - Bean Validation Implementation -->
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>8.0.1.Final</version> <!-- You can use latest compatible version -->
+        </dependency>
+
+        <!-- Needed for EL support (used in validation messages) -->
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.el</artifactId>
+            <version>4.0.2</version>
+        </dependency>
 
         <dependency>
             <groupId>io.jsonwebtoken</groupId>

--- a/src/main/java/com/icms/insurance/config/SwaggerConfig.java
+++ b/src/main/java/com/icms/insurance/config/SwaggerConfig.java
@@ -1,0 +1,62 @@
+package com.icms.insurance.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+
+public class SwaggerConfig {
+    public OpenAPI customOpenApi() {
+        return new OpenAPI().
+                info(new Info()
+                        .title("ICMS Insurance Project API")
+                        .version("1.0.0")
+                        .description("Swagger documentation for ICMS Insurance Modules (User, Policy, ED, Claim)")
+
+
+                );
+
+
+
+
+    }
+    @Bean
+    public GroupedOpenApi userApi(){
+           return GroupedOpenApi.builder()
+                   .group("User Module")
+                   .pathsToMatch("/api/auth/**")
+                   .build();
+    }
+
+
+
+    @Bean
+    public GroupedOpenApi policyApi() {
+        return GroupedOpenApi.builder()
+                .group("Policy Module")
+                .pathsToMatch("/api/admin/**")
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi eligibilityApi() {
+        return GroupedOpenApi.builder()
+                .group("Eligibility Module")
+                .pathsToMatch("/api/eligibility/**")
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi claimApi() {
+        return GroupedOpenApi.builder()
+                .group("Claim Module")
+                .pathsToMatch("/api/claims/**")
+                .build();
+    }
+
+
+
+}

--- a/src/main/java/com/icms/insurance/request/ClaimRequest.java
+++ b/src/main/java/com/icms/insurance/request/ClaimRequest.java
@@ -1,9 +1,11 @@
 package com.icms.insurance.request;
 
+import jakarta.validation.constraints.Null;
 import lombok.Data;
 
 @Data
 public class ClaimRequest {
+    @Null
     private Long policyId;
     private String reason;
 

--- a/src/main/java/com/icms/insurance/security/SecurityConfig.java
+++ b/src/main/java/com/icms/insurance/security/SecurityConfig.java
@@ -36,6 +36,10 @@ public class    SecurityConfig {
                 .requestMatchers("/api/policies/view/**").hasAnyRole("USER", "ADMIN")
                 .requestMatchers("/api/eligibility/**").hasRole("USER")
 
+                .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+
+     //           .anyRequest().permitAll()  // for swagger config
+
                 .anyRequest().authenticated()
                 .and()
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)


### PR DESCRIPTION
### ✅ Summary:
Integrated Swagger (SpringDoc OpenAPI) for the ICMS Project to enable interactive API documentation.

### 🔧 Changes Made:
- Added Swagger/OpenAPI dependency in `pom.xml`
- Created `SwaggerConfig` class under `config` package
- Enabled Swagger UI access at `/swagger-ui.html` and `/v3/api-docs`
- Applied annotations to controllers (e.g., `@Tag`, `@Operation`) for better documentation

### 📌 Benefits:
- Easy API testing for developers and testers
- Improves understanding of available endpoints
- Useful during frontend integration and external API usage

### 📂 Affected Files:
- `pom.xml`
- `SwaggerConfig.java`
- Updated all module controllers (e.g., `UserController`, `EligibilityController`)

✅ **Ready for review and merge into `main` branch.**
